### PR TITLE
Add support for sh files and mechanisms to pass arguments to functions

### DIFF
--- a/.github/workflows/build_lint.yml
+++ b/.github/workflows/build_lint.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Install aarch64-unknown-linux-gnu requisites
         run: sudo apt-get install g++-aarch64-linux-gnu -y
         if: matrix.os-target.target == 'aarch64-unknown-linux-gnu'
-      - name: Run cargo check
+      - name: Run cargo build
         run: cargo build --release --target ${{ matrix.os-target.target }}
       - name: Upload artifacts for reuse in release job
         uses: actions/upload-artifact@v3

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,5 +2,6 @@
     "[rust]": {
         "editor.defaultFormatter": "rust-lang.rust-analyzer",
         "editor.formatOnSave": true
-    }
+    },
+    "rust-analyzer.showUnlinkedFileNotification": false
 }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -62,7 +62,7 @@ dependencies = [
 
 [[package]]
 name = "arcanist"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "clap",
  "duct",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "arcanist"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ def example():
 To call `example` function, run `arcanist example`.
 
 ### Call function with arguments
-You can pass arguments to a function by specifying as much possitional arguments as required after the function name. For example, to call a python function named `example` and pass `1, 2, 3` as the function arguments, run `arcanist example 1 2 3`. All arguments passed will be strings. Full example:
+You can pass arguments to a function by specifying as much positional arguments as required after the function name. For example, to call a python function named `example` and pass `1, 2, 3` as the function arguments, run `arcanist example 1 2 3`. All arguments passed will be strings. Full example:
 
 ```python
 def example(*args):

--- a/README.md
+++ b/README.md
@@ -3,11 +3,11 @@ Arcanist is a multi-language function CLI runner. It can target functions writte
 
 Current supported languages:
 - Python (.py)
+- Sh and Bash (.sh)
 
 Coming next:
-- Sh and Bash (.sh)
-- Rust (.rs)
 - JavaScript (.js)
+- Rust (.rs)
 
 ## Usage
 Create an `arcanist.[ext]` using a supported language, define a function, and call `arcanist FUNCTION_NAME`. The `arcanist` file should be in the current or child directories. Example `arcanist.py` file:
@@ -18,12 +18,22 @@ def example():
 ```
 To call `example` function, run `arcanist example`.
 
-## Limitations
-### Calling a function with arguments
-Currently it is not possible to call a function with arguments.
+### Call function with arguments
+You can pass arguments to a function by specifying as much possitional arguments as required after the function name. For example, to call a python function named `example` and pass `1, 2, 3` as the function arguments, run `arcanist example 1 2 3`. All arguments passed will be strings. Full example:
 
+```python
+def example(*args):
+    print(args)
+
+arcanist example 1 2 3
+```
+
+## Limitations
 ### Multiple definitions of the same function across `arcanist.[ext]` files
-If a function is defined multiple times the function will be called multiple times. This will be solved with the definition of `arcanist.[yml|yaml]` files.
+If a function is defined multiple times across different `arcanist.[ext]` files, the function will be called multiple times. This will be solved with the definition of `arcanist.[yml|yaml]` files.
+
+### Arguments types
+All arguments passed to a function will be considered strings. There are currently no mechanisms to define each argument type.
 
 ## Installation
 Refer for the `Installation` section of the release you want to install. To install the latest version, visit the [latest installation instructions from the latest release](https://github.com/dloez/arcanist/releases/latest).

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,6 +11,7 @@ use wrapper::WrapperActions;
 enum SupportedExtension {
     Yaml,
     Python,
+    Bash,
 }
 
 trait Extension {
@@ -23,6 +24,7 @@ impl Extension for SupportedExtension {
         match self {
             SupportedExtension::Yaml => vec!["yaml", "yml"],
             SupportedExtension::Python => vec!["py"],
+            SupportedExtension::Bash => vec!["sh"],
         }
     }
 
@@ -37,6 +39,13 @@ impl Extension for SupportedExtension {
             }
             SupportedExtension::Python => {
                 let wrapper_kind = wrapper::WrapperKind::Python;
+                wrapper::Wrapper {
+                    spec_file_path,
+                    wrapper_kind,
+                }
+            }
+            SupportedExtension::Bash => {
+                let wrapper_kind = wrapper::WrapperKind::Bash;
                 wrapper::Wrapper {
                     spec_file_path,
                     wrapper_kind,
@@ -76,15 +85,23 @@ fn main() {
         .author("David L. <davidlopez.hellin@outlook.com>")
         .about("A 'Mage' inspired function runner with multi-language support")
         .arg(arg!([function_name] "Function to call").required(true))
+        .arg(
+            arg!([args] "Arguments to pass to the function")
+                .required(false)
+                .num_args(0..)
+                .default_missing_value("")
+                .default_value(""),
+        )
         .get_matches();
 
     let wrappers = get_spec_files_paths();
     let function_name = matches
         .get_one::<String>("function_name")
         .expect("required");
+    let args: Vec<&String> = matches.get_many::<String>("args").unwrap().collect();
     for wrapper in wrappers {
         if wrapper.does_function_exists(function_name) {
-            wrapper.call_function(function_name);
+            wrapper.call_function(function_name, &args);
         };
     }
 }

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -1,5 +1,6 @@
 use std::path::{Path, PathBuf};
 
+mod bash;
 mod python;
 mod yaml;
 
@@ -11,11 +12,12 @@ pub struct Wrapper {
 pub enum WrapperKind {
     Yaml,
     Python,
+    Bash,
 }
 
 trait WrapperKindActions {
     fn does_function_exists(&self, spec_file_path: &Path, function_name: &str) -> bool;
-    fn call_function(&self, spec_file_path: &Path, function_name: &str);
+    fn call_function(&self, spec_file_path: &Path, function_name: &str, args: &[&String]);
 }
 
 impl WrapperKindActions for WrapperKind {
@@ -23,13 +25,15 @@ impl WrapperKindActions for WrapperKind {
         match self {
             WrapperKind::Yaml => todo!(),
             WrapperKind::Python => python::does_function_exists(spec_file_path, function_name),
+            WrapperKind::Bash => bash::does_function_exists(spec_file_path, function_name),
         }
     }
 
-    fn call_function(&self, spec_file_path: &Path, function_name: &str) {
+    fn call_function(&self, spec_file_path: &Path, function_name: &str, args: &[&String]) {
         match self {
             WrapperKind::Yaml => todo!(),
-            WrapperKind::Python => python::call_function(spec_file_path, function_name),
+            WrapperKind::Python => python::call_function(spec_file_path, function_name, args),
+            WrapperKind::Bash => bash::call_function(spec_file_path, function_name, args),
         }
     }
 }
@@ -37,7 +41,7 @@ impl WrapperKindActions for WrapperKind {
 pub trait WrapperActions {
     fn print_spec_file_path(&self);
     fn does_function_exists(&self, function_name: &str) -> bool;
-    fn call_function(&self, function_name: &str);
+    fn call_function(&self, function_name: &str, args: &[&String]);
 }
 
 impl WrapperActions for Wrapper {
@@ -50,8 +54,8 @@ impl WrapperActions for Wrapper {
             .does_function_exists(&self.spec_file_path, function_name)
     }
 
-    fn call_function(&self, function_name: &str) {
+    fn call_function(&self, function_name: &str, args: &[&String]) {
         self.wrapper_kind
-            .call_function(&self.spec_file_path, function_name)
+            .call_function(&self.spec_file_path, function_name, args)
     }
 }


### PR DESCRIPTION
This feature allows users to call functions defined in `.sh` scripts and pass arguments to all language functions.

To pass arguments to functions you can add as many positional arguments as required after the function name when calling arcanist.