### PR TITLE
Add version to CLI description from Cargo.toml

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -62,7 +62,7 @@ dependencies = [
 
 [[package]]
 name = "arcanist"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "clap",
  "duct",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "arcanist"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,6 @@
 use clap::{arg, Command};
 use glob::glob;
-use std::path::PathBuf;
+use std::{env, path::PathBuf};
 use strum::IntoEnumIterator;
 use strum_macros::EnumIter;
 
@@ -80,8 +80,11 @@ fn get_spec_files_paths() -> Vec<wrapper::Wrapper> {
 }
 
 fn main() {
+    let version = env::var("CARGO_PKG_VERSION").expect("Could not get 'CARGO_PKG_VERSION'");
+    let version_static: &'static str = Box::leak(version.into_boxed_str());
+
     let matches = Command::new("Arcanist")
-        .version("0.1")
+        .version(version_static)
         .author("David L. <davidlopez.hellin@outlook.com>")
         .about("A 'Mage' inspired function runner with multi-language support")
         .arg(arg!([function_name] "Function to call").required(true))


### PR DESCRIPTION
Instead of hardcoding the version to the CLI program description, now it is read from `CARGO_PKG_VERSION` environment variable and directly referenced on code. This fixes the issue where new releases would still present and old version in the command `arcanist - --version`.